### PR TITLE
Avoid logout() processing when cosign not being used

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,23 @@
 # phplist-cosign
 Log in and out of phplist with Cosign.
 
-#Installation
-Place CosignPlugin.php in your plugins directory. This directory may be different for different installs. By default, the directory will be [site-root]/lists/admin/plugins
+## Installation ##
 
-#Compatability
-So far this has only been tested with version 3.X
+### Dependencies ###
+
+Requires php version 5.3.0 or later.
+
+### Install through phplist ###
+Install on the Plugins page (menu Config > Manage Plugins) using the package URL `https://github.com/bradallenfisher/phplist-plugin-cosign/archive/master.zip`
+
+### Install manually ###
+Download the plugin zip file from <https://github.com/bradallenfisher/phplist-plugin-cosign/archive/master.zip>
+
+Expand the zip file, then place CosignPlugin.php in your plugins directory.
+This directory may be different for different installs. By default, the directory will be [site-root]/lists/admin/plugins
+
+###Settings###
+In the Cosign group on the Settings page you can specify:
+
+* The value for REMOTE_REALM, if used.
+* The Cosign logout URL

--- a/plugins/CosignPlugin.php
+++ b/plugins/CosignPlugin.php
@@ -84,17 +84,17 @@ class CosignPlugin extends phplistPlugin
             );
 
             if ($row) {
-                    list($id, $password, $superuser, $privileges) = $row;
-                    $_SESSION['adminloggedin'] = $_SERVER['REMOTE_ADDR'];
-                    $_SESSION['logindetails'] = array(
-                            'adminname' => $_SERVER['REMOTE_USER'],
-                            'id' => $id,
-                            'superuser' => $superuser,
-                            'passhash' => $password,
-                    );
+                list($id, $password, $superuser, $privileges) = $row;
+                $_SESSION['adminloggedin'] = $_SERVER['REMOTE_ADDR'];
+                $_SESSION['logindetails'] = array(
+                    'adminname' => $_SERVER['REMOTE_USER'],
+                    'id' => $id,
+                    'superuser' => $superuser,
+                    'passhash' => $password,
+                );
 
                 if ($privileges) {
-                        $_SESSION['privileges'] = unserialize($privileges);
+                    $_SESSION['privileges'] = unserialize($privileges);
                 }
             }
         }
@@ -103,6 +103,9 @@ class CosignPlugin extends phplistPlugin
     //When user logs out redirect them to the webaccess logout page and then back to here.
     public function logout()
     {
+        if (empty($_SERVER['REMOTE_USER'])) {
+            return;
+        }
         // this is set in the settings page of phplist: lists/admin/?page=configure under the cosign section
         $cosignLogout = getConfig('cosign_logout');
 
@@ -113,7 +116,6 @@ class CosignPlugin extends phplistPlugin
             $service_name = $_SERVER['COSIGN_SERVICE'];
             setcookie( $service_name , "null", time()-1, '/', "", 1 );
         }
-
 
         //remove server vars on logout as well.
         $_SERVER['REMOTE_USER'] = "";


### PR DESCRIPTION
A few small changes:
- Avoid logout() processing when REMOTE_USER not set. This allows the plugin to be installed with no adverse effect when cosign is not being used.
- Tidy up indentation
- Expand readme for installation
